### PR TITLE
Bug-fix: Linux key case

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 For the dictionary keys:
 use "darwin" for Mac OS
 use "windows" for Windows
-use the result of `uname -s` for POSIX/Linux
+use "linux" for Linux/FreeBSD
+use the result of `uname -s` for anything else
 
 ```python
 git_repository(

--- a/os_dependent_http_archive.bzl
+++ b/os_dependent_http_archive.bzl
@@ -24,6 +24,8 @@ def _cpu_value(repository_ctx):
   os_name = repository_ctx.os.name.lower()
   if os_name.startswith("mac os"):
     return "darwin"
+  if any([x in os_name for x in ["linux", "freebsd"]]):
+    return "linux"
   if os_name.find("windows") != -1:
     return "windows"
   result = repository_ctx.execute(["uname", "-s"])


### PR DESCRIPTION
Currently on a Linux machine, the `_cpu_value(repository_ctx)` function returns the key "Linux". Which breaks everything downstream as it expects "linux". 

